### PR TITLE
track not-translated from react too

### DIFF
--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -50,6 +50,12 @@ export default function Article({ document }: DocumentProps) {
         document.slug === 'Archive' || document.slug.startsWith('Archive/');
     const locale = getLocale();
 
+    useEffect(() => {
+        if (document.locale !== locale) {
+            mdn.analytics.trackError('Translation Pending', 'displayed');
+        }
+    }, [document, locale]);
+
     return (
         /*
          * The "text-content" class and "wikiArticle" id are required


### PR DESCRIPTION
`mdn` is a global added to `window` so this would only work if you're in a browser and not in NodeJS. However, effects (`useEffect`) only trigger in React when in the browser. 